### PR TITLE
upgrade opvenc and numpy versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-numpy==1.19.4
-opencv-python==4.4.0.46
+numpy==1.23.1
+opencv-python==4.6.0.66


### PR DESCRIPTION
Old versions of opencv don't build on mac m1